### PR TITLE
Pile eval on transformers and friends

### DIFF
--- a/eval_pile.py
+++ b/eval_pile.py
@@ -265,7 +265,7 @@ def main():
     else:
         raise ValueError(f"Unknown format type: {format_type}")
 
-    model = load_nln_hf_model(model=hf_model)
+    model = load_nln_hf_model(model=model)
 
     # Evaluate model
     ce_loss = evaluate_on_pile_ce(model, dataset_name, num_samples)


### PR DESCRIPTION
Add various options for running eval, namely HF transformers trained using our train.py script.

Test:
```
python eval_pile.py -m results/checkpoint-1200 -f transformers --slay-ln
python eval_pile.py -m submarat/model-without-ln -f transformers --slay-ln
```
